### PR TITLE
:3000がurl に現れないように、nginx の設定追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
 
   backend:
     build: ./backend
-    ports:
-      - 3000:3000
     environment:
       POSTGRES_USER: $POSTGRES_USER
       POSTGRES_PASSWORD: $POSTGRES_PASSWORD

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
 COPY --from=builder /usr/src/app/wait-for-it.sh ./wait-for-it.sh
 
-RUN sed -i '9a \\t\ttry_files \$uri /index.html;' /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,61 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri /index.html;
+    }
+
+    location /api/ {
+      proxy_pass http://backend:3000/;
+    }
+
+    # https://socket.io/docs/v3/reverse-proxy/
+    location /socket.io/ {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $host;
+
+      proxy_pass http://backend:3000;
+
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    # error_page   500 502 503 504  /50x.html;
+    # location = /50x.html {
+    #     root   /usr/share/nginx/html;
+    # }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+


### PR DESCRIPTION
やったこと

- 本番環境で、:3000 がurl に現れないようにした。
  - localhost/api にアクセスした際、nginx がhttp://backend:3000 に飛ばす。
    [Vite\+FastAPI\+NGINX\+Dockerの環境構築 \- Qiita](https://qiita.com/gaitou2048/items/4c187ff3ed60de1cb366)
    [nginxのproxy\_passでハマった \- Qiita](https://qiita.com/master-of-sugar/items/6dc7c03a1f600c1ec24a)
  - websocket の場合、uri が/socket.io/ になるっぽい。
    [Behind a reverse proxy \| Socket\.IO](https://socket.io/docs/v3/reverse-proxy/)