### PR TITLE
compose を使ってecs にデプロイ

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   frontend:
+    image: ${FRONTEND_IMAGE}
     build: ./frontend
     ports:
       - 80:80
@@ -14,6 +15,7 @@ services:
     command: ["sh", "-c", "nginx -g \"daemon off;\""]
 
   backend:
+    image: ${BACKEND_IMAGE}
     build: ./backend
     restart: on-failure
     depends_on:
@@ -43,7 +45,7 @@ services:
     volumes:
       - postgres-data-volume:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready || exit 1"]
+      test: ["CMD-SHELL", "pg_isready -U `cat $${POSTGRES_USER_FILE}` || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -69,3 +71,16 @@ secrets:
     file: ./secrets/postgres_password.txt
   postgres_db:
     file: ./secrets/postgres_db.txt
+
+x-aws-cloudformation:
+  Resources:
+    FrontendTCP80Listener:
+      Properties:
+        Certificates:
+          - CertificateArn: "${CERTIFICATE_ARN}"
+        Protocol: HTTPS
+        Port: 443
+    Fronttier80Ingress:
+      Properties:
+        FromPort: 443
+        ToPort: 443

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,6 @@
 server {
-    listen       80;
-    server_name  localhost;
+    listen       80 default_server;
+    server_name  transpong-42-mk.com;
 
     #access_log  /var/log/nginx/host.access.log  main;
 


### PR DESCRIPTION
やったこと

## AWS のsetup (AWSコンソールでの操作)

参考サイト  
[AWS の開発環境を設定する方法 \| はじめに](https://aws.amazon.com/jp/getting-started/guides/setup-environment/)  

## ECSへのデプロイ (ターミナルでの操作)

基本的には、`docker compose up`するだけで、全部勝手にやってくれる！  
今回は、独自のdocker imageを使うため、ecr を使用する。

参考サイト  
[docker\-compose\.ymlを全自動でAWS ECSにデプロイ](https://zenn.dev/thr3a/articles/b71b16c88387d2)  
[Docker composeとAWS\(ECR/ECS\)デプロイ](https://zenn.dev/soreiyu/articles/29fe1cacc071bd)  
[docker\-compose\.ymlを使ったAWS ECS\+Fargate構築・デプロイ \- Qiita](https://qiita.com/morita-toyscreation/items/e30cd35133f0b3f81452)  

公式サイト  
[Deploy applications on Amazon ECS using Docker Compose \| Containers](https://aws.amazon.com/jp/blogs/containers/deploy-applications-on-amazon-ecs-using-docker-compose/)  
[ECS での Docker コンテナーのデプロイ \| Docker ドキュメント](https://matsuand.github.io/docs.docker.jp.onthefly/cloud/ecs-integration/)  
[Using Amazon ECR with the AWS CLI \- Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/getting-started-cli.html)

## カスタムドメインを取得。(AWSコンソールでの操作)

このままだと、勝手に決められたドメインなので、ドメインを取得。

参考サイト  
[【初心者向け】AWSでドメイン名を取得する方法！Route53使用 \- ひよわさんでもエンジニア](https://hiyowa-na-engineer.com/aws-get-domain/)  
[ AWS画像付き解説】HTTPリクエストをHTTPSにリダイレクトする方法 続きを見る](https://hiyowa-na-engineer.com/aws-wordpress-how-to-alb/#Route53)
[Route53\+ACM\+ALB\+EC2でHTTPS接続するまで \- Qiita](https://qiita.com/m-kazu/items/aa44789f9183f5a61104)

公式サイト  
[新しいドメインの登録 \- Amazon Route 53](https://docs.aws.amazon.com/ja_jp/Route53/latest/DeveloperGuide/domain-register.html)  

## SSL証明書を取得。(AWSコンソールでの操作)

おそらく、Cookie オプションの`secure: true` により、ログインしても、Cookie にセットされてなかった。  
https 接続するため、SSL証明書を取得して、取得したカスタムドメインに紐づける。  

参考サイト  
[ACMでSSL証明書を発行してみた](https://zenn.dev/mn87/articles/90609fffd8c634)

公式サイト  
[パブリック証明書をリクエストする \- AWS Certificate Manager](https://docs.aws.amazon.com/ja_jp/acm/latest/userguide/gs-acm-request-public.html)

## https 接続にする。(このgitリポジトリでの操作)

docker-compose.yml に、https 接続用の設定を追加。  
また、公式記載のコードだけでは、アクセスできなかったため、以下のissue を参考に、コードを追加。  
(`docker compose down` して) `docker compose up`で、ecs にデプロイ。
route53 で、カスタムドメインとロードバランサーのドメインを紐づけるレコードを追加。(AWSコンソールでの操作)  
https 接続できて、Cookie にセットできた！  

参考サイト
[ECS での Docker コンテナーのデプロイ \| Docker ドキュメント](https://matsuand.github.io/docs.docker.jp.onthefly/cloud/ecs-integration/#setting-ssl-termination-by-load-balancer)  
`docker/compose-cli`の`issues/1472`