### PR TITLE
fork 用にtest.yml 変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,16 @@
 
 name: build
 
-on: [pull_request]
+on:
+  pull_request:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ( github.event.pull_request.head.repo.fork == false ) ||
+        ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
     steps:
       - uses: actions/checkout@v3
       - name: backend install
@@ -19,6 +24,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    if: ( github.event.pull_request.head.repo.fork == false ) ||
+        ( contains(github.event.pull_request.labels.*.name, 'safe to test') )
     steps:
       - uses: actions/checkout@v3
       - name: create .env


### PR DESCRIPTION
やったこと

fork 先 -> fork 元のプルリクでは、actions のpull_request イベントで、secrets を参照できない。
理由は、secrets の内容を、どこかに送信する処理を仕込まれたら、やばいから。
pull_request_target イベントであれば、secrets を参照できるが、安全にする処理が必要。
公式ブログを参考に、`safe to test`というラベルがつけられたらactions 実行するようにした。

[fork されたリポジトリからのプルリクで Actions のシークレットを参照できるようにしたい](https://zenn.dev/odan/scraps/cce2165dc91080)
[欅樹雑記: GitHub Actionsでシークレットを扱うときの注意](https://blog.zelkova.cc/2020/05/attentions-of-using-secrets-on-github-actions.html)
[GitHub Actionの\`on: pull\_request\`と\`on: pull\_request\_target\`の違いMEMO \- Madogiwa Blog](https://madogiwa0124.hatenablog.com/entry/2022/05/29/110148)